### PR TITLE
Fixed Compiling Error from WP-34-CC-page

### DIFF
--- a/pubspec.lock
+++ b/pubspec.lock
@@ -114,7 +114,6 @@ packages:
       url: "https://pub.dartlang.org"
     source: hosted
     version: "0.15.0"
-<<<<<<< HEAD
   intl:
     dependency: "direct main"
     description:
@@ -122,8 +121,6 @@ packages:
       url: "https://pub.dartlang.org"
     source: hosted
     version: "0.17.0"
-=======
->>>>>>> dec6982c9564fa9df1fb9ab44a37c957a6fbb40b
   js:
     dependency: transitive
     description:
@@ -131,16 +128,6 @@ packages:
       url: "https://pub.dartlang.org"
     source: hosted
     version: "0.6.3"
-<<<<<<< HEAD
-=======
-  intl:
-    dependency: "direct main"
-    description:
-      name: intl
-      url: "https://pub.dartlang.org"
-    source: hosted
-    version: "0.17.0"
->>>>>>> dec6982c9564fa9df1fb9ab44a37c957a6fbb40b
   lints:
     dependency: transitive
     description:


### PR DESCRIPTION
We reverted the revert and fixed the pubspec.lock file.